### PR TITLE
ci: add concurrency settings to cancel outdated workflow runs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   audit:
     uses: gifnksm/rust-template/.github/workflows/reusable-audit.yml@main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   cd:
     uses: gifnksm/rust-template/.github/workflows/reusable-cd.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Add `concurrency` settings to all workflows to cancel outdated runs when a PR or branch is updated.

- On the default branch: `cancel-in-progress: false` (runs are not cancelled)
- On PRs and other branches: `cancel-in-progress: true` (older runs are cancelled)

Workflows updated:
- `ci.yml`
- `cd.yml`
- `audit.yml`