### PR TITLE
chore: simplify CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,17 +4,8 @@ on:
   push:
     tags:
       - "v?[0-9]+.[0-9]+.[0-9]+"
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-
-env:
-  CARGO_TERM_COLOR: always
+permissions: {}
 
 jobs:
   release:
@@ -30,20 +21,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-
-  cd-complete:
-    needs:
-      - release
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    permissions: {}
-    steps:
-      - name: CD complete
-        run: |
-          if ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}; then
-            echo "CD succeeded"
-          else
-            echo "CD failed"
-            exit 1
-          fi
-        shell: bash


### PR DESCRIPTION
## Summary
- simplify CD workflow to run only on version tag pushes
- remove redundant `cd-complete` aggregation job
- keep the workflow focused on GitHub release publication

## Notes
- tag filter uses GitHub Actions path/tag pattern syntax
- release job remains unchanged in behavior for tag-triggered runs
