### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ github-actions = { workflows = "ci.yml" }
 codecov = true
 
 [dev-dependencies]
-clap = { version = "4.5.18", features = ["derive"] }
+clap = { version = "4.6.0", features = ["derive"] }
 
 [build-dependencies]
 


### PR DESCRIPTION
This PR updates dependencies using:
- `cargo upgrade --compatible`: Updates semver-compatible direct dependency versions in `Cargo.toml`
- `cargo update`: Updates `Cargo.lock` with the latest compatible versions (including indirect dependencies)