### PR TITLE
ci: unify GITHUB_TOKEN permissions across workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   security-audit:
     name: Security Audit
@@ -50,7 +52,6 @@ jobs:
       - cargo-deny
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: Audit complete
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
@@ -285,7 +287,6 @@ jobs:
       - actionlint
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: CI complete
         run: |

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update-deps:
     name: Update Dependencies


### PR DESCRIPTION
## Summary

Unify `permissions` declarations across all GitHub Actions workflows by:

1. Adding `permissions: {}` at the **workflow level** as a secure default in all workflows
2. Removing redundant `permissions: {}` from individual jobs that were only restating the default
3. Keeping explicit per-job overrides only where elevated permissions are actually needed

Jobs with explicit elevated permissions (unchanged):
- `cd.yml` / `release`: `contents: write` (for GitHub releases)
- `audit.yml` / `security-audit`: `issues: write` (for issue creation)
- `update-deps.yml` / `update-deps`: `contents: read`

Fixes CodeQL alerts: `actions/missing-workflow-permissions`